### PR TITLE
allow the use of php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": "^7.1.8",
+        "php": "^7.1.8|^8.0",
         "ext-ctype": "*",
         "ext-sockets": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.*",
-        "phpunit/phpunit": "^7.0"
+        "orchestra/testbench": "^3.8|^7.0",
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This just allows the use of php 8. As far as I see this doesn't break the package in any way, I made sure to run the tests.